### PR TITLE
連想配列を返却するPHPファイルをアップロードして、連結したkey一覧をcsv出力する機能を実装

### DIFF
--- a/src/app/Http/Controllers/ArrayToCsvController.php
+++ b/src/app/Http/Controllers/ArrayToCsvController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Class ArrayToCsvController
+ * @package App\Http\Controllers
+ */
+class ArrayToCsvController extends Controller
+{
+    /**
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function index()
+    {
+        return view('array_to_csv.index');
+    }
+
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function convertAndDownload(Request $request)
+    {
+        // todo: jsonファイルにも対応
+        // todo: ファイル名をkeyの先頭にくっつけているけど、先頭に付けたいkeyがあれば自由に決められるように入力エリアを設ける
+        // todo: DLできるcsvをDBに保管しておいて、自由にDLできるようにする？（ログインしてる場合だけ使える機能として）
+        // todo: メソッド内の処理を別クラスに分ける（json対応時など、処理が複雑化した際にも見通しがよくなる）
+
+        $file = $request->file('file');
+        $fileNameWithoutExtension = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+        $target = require $file->getRealPath();
+        unlink($file->getRealPath());
+
+        $chainedKeys = [];
+        $keyPrefix = $fileNameWithoutExtension;
+        $this->addChainedKeysToArray($keyPrefix, $target, $chainedKeys);
+
+        $completeKeysCsv = '';
+
+        foreach ($chainedKeys as $line) {
+            $completeKeysCsv .= $line . "\n";
+        }
+
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="' . $fileNameWithoutExtension . '.csv"',
+        ];
+
+        return response()->make($completeKeysCsv, 200, $headers);
+    }
+
+    /**
+     * @param string           $chainedKey
+     * @param array|string|int $val
+     * @param array            $completeKeys
+     */
+    private function addChainedKeysToArray(string $chainedKey, $val,array &$completeKeys)
+    {
+        if (is_array($val)) {
+            foreach ($val as $currentKey => $item) {
+                $newPrefix = $chainedKey . '.' . $currentKey;
+                $this->addChainedKeysToArray($newPrefix, $item, $completeKeys);
+            }
+        } else {
+            $completeKeys[] = $chainedKey;
+        }
+    }
+
+
+}

--- a/src/resources/views/array_to_csv/index.blade.php
+++ b/src/resources/views/array_to_csv/index.blade.php
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    {{ Html::style(mix('/css/app.css')) }}
+</head>
+<body>
+<div id="app" class="p-5">
+    <h2>連想配列のキー連結機能</h2>
+    <p>
+        laravelの多言語対応リソースファイルなど、<br>
+        連想配列を返却するphpファイルをアップロードしてください。<br>
+        入れ子になっている連想配列のキーを連結し、<br>
+        有効なキーの一覧をcsvファイルとして出力します。<br>
+        （アップロードしたファイル名が全てのキーの先頭として扱われます）
+    </p>
+
+    {{ Form::open(['route' => 'array_to_csv.convert_and_download', 'files' => true]) }}
+    <div>{{ Form::file('file') }}</div>
+    <div class="mt-3">{{ Form::submit('Convert & DL') }}</div>
+    {{ Form::close() }}
+
+
+</div>
+{{ Html::script(mix('js/memo/index.js')) }}
+</body>
+</html>

--- a/src/resources/views/home.blade.php
+++ b/src/resources/views/home.blade.php
@@ -13,5 +13,6 @@
     <a href="/auth/login">ログイン</a><br>
     <a href="/auth/register">会員登録</a>
 @endif
+<div><a href="/array_to_csv">連想配列のキー連結機能</a></div>
 </body>
 </html>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -22,7 +22,14 @@ Route::get('/home', function () {
     return view('home');
 });
 
-Route::prefix('auth')->namespace('Auth')->group(function (){
+Route::prefix('array_to_csv')->name('array_to_csv.')->group(function () {
+    Route::get('/', 'ArrayToCsvController@index')->name('index');
+    Route::post('/', 'ArrayToCsvController@convertAndDownload')->name('convert_and_download');
+});
+
+
+
+Route::prefix('auth')->namespace('Auth')->group(function () {
     Route::get('/register', 'RegisterController@showRegistrationForm');
     Route::post('/register', 'RegisterController@register');
     Route::get('/login', 'LoginController@showLoginForm')->name('login');
@@ -30,7 +37,7 @@ Route::prefix('auth')->namespace('Auth')->group(function (){
     Route::get('/logout', 'LoginController@logout')->name('logout');
 });
 
-Route::prefix('memo')->name('memo.')->middleware('auth')->group(function (){
+Route::prefix('memo')->name('memo.')->middleware('auth')->group(function () {
     Route::get('/', 'MemoController@index')->name('index');
     Route::post('/store', 'MemoController@store')->name('store');
     Route::delete('/{id}/destroy', 'MemoController@destroy')->name('destroy');


### PR DESCRIPTION
## やったこと
- Laravelの言語リソースファイルの有効なキー値一覧を取得する為に実装
- ログインしなくても使える機能として実装

## やってないこと
- 見た目

## 後でやりたいこと
- jsonファイルにも対応
- ファイル名をkeyの先頭にくっつけているけど、先頭に付けたいkeyがあれば自由に決められるように入力エリアを設ける
- DLできるcsvをDBに保管しておいて、自由にDLできるようにする？（ログインしてる場合だけ使える機能として）
- メソッド内の処理を別クラスに分ける（json対応時など、処理が複雑化した際にも見通しがよくなる）